### PR TITLE
Show and search custom reference on product/service list page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-
+- NEW : Add references in product list and add corresponding search functionality *28/06/2024*
 
 ## Release 1.3
 

--- a/admin/productbycompany_setup.php
+++ b/admin/productbycompany_setup.php
@@ -114,6 +114,8 @@ setup_print_on_off('PBC_USE_CUSTOM_REF_SUPPLIER'); // Utiliser les références 
 
 setup_print_on_off('PBC_DONT_PRESELECT_CUSTOM_REF'); // Ne pas présélectionner par défaut la référence personnalisé
 
+setup_print_on_off('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST');
+
 // Example with imput
 //setup_print_input_form_part('CONSTNAME', $langs->trans('ParamLabel'));
 

--- a/class/actions_productbycompany.class.php
+++ b/class/actions_productbycompany.class.php
@@ -74,7 +74,7 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
 
     public function printFieldListWhere($parameters, &$object, &$action, $hookmanager)
     {
-        if ($parameters['currentcontext'] == 'productservicelist') {
+        if ($parameters['currentcontext'] == 'productservicelist' && getDolGlobalString('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST')) {
             $search_companyproductreference = GETPOST("search_companyproductreference", 'alpha');
             $hookmanager->resPrint = " AND EXISTS (SELECT 1 FROM ".MAIN_DB_PREFIX."product_by_company AS pbc WHERE pbc.fk_product = p.rowid AND pbc.ref LIKE CONCAT('%', '".$search_companyproductreference."', '%')) ";
         }
@@ -83,7 +83,7 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
     
     public function printFieldListOption($parameters, &$object, &$action, $hookmanager)
 	{
-        if ($parameters['currentcontext'] == 'productservicelist') {
+        if ($parameters['currentcontext'] == 'productservicelist' && getDolGlobalString('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST')) {
             $search_companyproductreference = GETPOST("search_companyproductreference", 'alpha');
 
             print '<td class="liste_titre left">';
@@ -95,7 +95,7 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
 
     public function printFieldListTitle($parameters, &$object, &$action, $hookmanager)
 	{
-        if ($parameters['currentcontext'] == 'productservicelist') {
+        if ($parameters['currentcontext'] == 'productservicelist' && getDolGlobalString('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST')) {
             global $langs;
 
             $langs->load('productbycompany@productbycompany');
@@ -111,7 +111,7 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
 
     public function printFieldListValue($parameters, &$object, &$action, $hookmanager)
 	{
-        if ($parameters['currentcontext'] == 'productservicelist') {
+        if ($parameters['currentcontext'] == 'productservicelist' && getDolGlobalString('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST')) {
             $product = $parameters["obj"];
 
             print '<td class="center nowraponall">';

--- a/class/actions_productbycompany.class.php
+++ b/class/actions_productbycompany.class.php
@@ -22,6 +22,7 @@
  *          Put some comments here
  */
 require_once __DIR__ . '/../backport/v19/core/class/commonhookactions.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
 
 /**
  * Class ActionsProductByCompany
@@ -69,6 +70,67 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
 	public function doActions($parameters, &$object, &$action, $hookmanager)
 	{
 
+	}
+
+    public function printFieldListWhere($parameters, &$object, &$action, $hookmanager)
+    {
+        if ($parameters['currentcontext'] == 'productservicelist') {
+            $search_companyproductreference = GETPOST("search_companyproductreference", 'alpha');
+            $hookmanager->resPrint = " AND EXISTS (SELECT 1 FROM ".MAIN_DB_PREFIX."product_by_company AS pbc WHERE pbc.fk_product = p.rowid AND pbc.ref LIKE CONCAT('%', '".$search_companyproductreference."', '%')) ";
+        }
+        return 0;
+    }
+    
+    public function printFieldListOption($parameters, &$object, &$action, $hookmanager)
+	{
+        if ($parameters['currentcontext'] == 'productservicelist') {
+            $search_companyproductreference = GETPOST("search_companyproductreference", 'alpha');
+
+            print '<td class="liste_titre left">';
+            print '<input class="flat" type="text" name="search_companyproductreference" size="12" value="'.dol_escape_htmltag($search_companyproductreference).'">';
+            print '</td>';
+        }
+        return 0;
+	}
+
+    public function printFieldListTitle($parameters, &$object, &$action, $hookmanager)
+	{
+        if ($parameters['currentcontext'] == 'productservicelist') {
+            global $langs;
+
+            $langs->load('productbycompany@productbycompany');
+
+            $param = $parameters["param"];
+            $sortfield = $parameters["sortfield"];
+            $sortorder = $parameters["sortorder"];
+            
+            print_liste_field_titre($langs->trans("ProductRefByCompany"), $_SERVER["PHP_SELF"], "", "", $param, '', $sortfield, $sortorder, 'center nowrap ');
+        }
+        return 0;
+	}
+
+    public function printFieldListValue($parameters, &$object, &$action, $hookmanager)
+	{
+        if ($parameters['currentcontext'] == 'productservicelist') {
+            $product = $parameters["obj"];
+
+            print '<td class="center nowraponall">';
+
+            $sql = "SELECT ref FROM ".MAIN_DB_PREFIX."product_by_company WHERE fk_product = '".$product->rowid."'";
+            $resql = $this->db->query($sql);
+            if ($resql) {
+                $num = $this->db->num_rows($resql);
+                for ($i = 0; $i < $num; $i++) {
+                    $dbObject = $this->db->fetch_object($resql);
+                    if (!empty($dbObject->ref)) {
+                        print $dbObject->ref."<br />";
+                    }
+                }
+            }
+
+            print '</td>';
+        }
+        return 0;
 	}
 
 	public function formEditProductOptions($parameters, &$object, &$action, $hookmanager)

--- a/class/actions_productbycompany.class.php
+++ b/class/actions_productbycompany.class.php
@@ -76,7 +76,9 @@ class ActionsProductByCompany extends \productbycompany\RetroCompatCommonHookAct
     {
         if ($parameters['currentcontext'] == 'productservicelist' && getDolGlobalString('PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST')) {
             $search_companyproductreference = GETPOST("search_companyproductreference", 'alpha');
-            $hookmanager->resPrint = " AND EXISTS (SELECT 1 FROM ".MAIN_DB_PREFIX."product_by_company AS pbc WHERE pbc.fk_product = p.rowid AND pbc.ref LIKE CONCAT('%', '".$search_companyproductreference."', '%')) ";
+            if (!empty($search_companyproductreference)) {
+                $hookmanager->resPrint = " AND EXISTS (SELECT 1 FROM ".MAIN_DB_PREFIX."product_by_company AS pbc WHERE pbc.fk_product = p.rowid AND pbc.ref LIKE CONCAT('%', '".$search_companyproductreference."', '%')) ";
+            }
         }
         return 0;
     }

--- a/core/modules/modProductByCompany.class.php
+++ b/core/modules/modProductByCompany.class.php
@@ -103,6 +103,7 @@ class modProductByCompany extends DolibarrModules
 				,'ordersuppliercard'
 				,'invoicesuppliercard'
 				,'supplier_proposalcard'
+				,'productservicelist'
 			),
 			'triggers' => 1,
 			'css' => array(

--- a/langs/de_DE/productbycompany.lang
+++ b/langs/de_DE/productbycompany.lang
@@ -56,3 +56,6 @@ RefIsAMandatoryField=Das Feld Referenz darf nicht leer sein
 Customize=Anpassen
 
 SearchForCustomerCustomRef = Produktreferenz des Kunden
+
+# product list
+ProductRefByCompany = Produktreferenz Geschäftspartner

--- a/langs/de_DE/productbycompany.lang
+++ b/langs/de_DE/productbycompany.lang
@@ -16,6 +16,7 @@ ParamHelp=Hilfe Text
 PBC_DONT_PRESELECT_CUSTOM_REF=Benutzerdefinierte Referenz nicht standardmäßig vorauswählen
 PBC_USE_CUSTOM_REF_CUSTOMER=Benutzerdefinierte Referenzen auf Kundendokumenten verwenden
 PBC_USE_CUSTOM_REF_SUPPLIER=Benutzerdefinierte Referenzen auf Lieferantendokumenten verwenden
+PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST=Benutzerdefinierte Referenzen auf Produktlisten Seite anzeigen und suchen
 
 # TAB
 TabProductByCompanyFromProduct=Referenz/Bezeichnung pro Kunde

--- a/langs/en_US/productbycompany.lang
+++ b/langs/en_US/productbycompany.lang
@@ -16,6 +16,7 @@ ParamHelp=Help content
 PBC_DONT_PRESELECT_CUSTOM_REF=Do not pre-select the custom reference by default
 PBC_USE_CUSTOM_REF_CUSTOMER=Use personalized references on customer documents
 PBC_USE_CUSTOM_REF_SUPPLIER=Use personalized references on supplier documents
+PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST=Show and search personalized references on product list page
 
 # TAB
 TabProductByCompanyFromProduct=Ref./linked by customer
@@ -56,4 +57,7 @@ RefIsAMandatoryField=The Ref field cannot be empty
 Customize=Customize
 
 SearchForCustomerCustomRef =Customer product code
+
+# product list
+ProductRefByCompany = Customized Ref.
 

--- a/langs/fr_FR/productbycompany.lang
+++ b/langs/fr_FR/productbycompany.lang
@@ -16,6 +16,7 @@ ParamHelp=Le contenu de l'aide
 PBC_DONT_PRESELECT_CUSTOM_REF=Ne pas présélectionner par défaut la référence personnalisé
 PBC_USE_CUSTOM_REF_CUSTOMER=Utiliser les références personnalisées sur les documents clients
 PBC_USE_CUSTOM_REF_SUPPLIER=Utiliser les références personnalisées sur les documents fournisseurs
+PBC_USE_CUSTOM_REF_SEARCH_ON_PRODUCTLIST=Utilisez des références personnalisées pour afficher et rechercher sur la page des listes de produits
 
 # TAB
 TabProductByCompanyFromProduct=Réf./libellé par client
@@ -56,3 +57,6 @@ RefIsAMandatoryField=Le champs Ref ne peut être vide
 Customize=Personnaliser
 
 SearchForCustomerCustomRef = Réf produit du client
+
+# product list
+ProductRefByCompany = Référence du produit du tiers


### PR DESCRIPTION
Hi,

this change adds a new column to product/service list view and adds the function of searching through them. Use case would be that a customer is calling and asks if you have the product in stock but he has only his custom reference.

French translation was auto translated, please check if this makes sense for you. I was not able to find a possibilty to show/hide the column with the normal functionality so the column can be shown/hidden only via a global parameter. Let me know if you have a better idea to integrate it in the flow.

Regards,
Sven